### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -1,8 +1,8 @@
 base:
   build: .
   ports:
-    - "3600:3600"
+    - "3602:3602"
   environment:
-    PORT: 3600
+    PORT: 3602
     NODE_PATH: app/src
   container_name: gfw-prodes-loss-api

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -3,15 +3,16 @@ services:
   develop:
     build: .
     ports:
-      - "3600:3600"
+      - "3602:3602"
     container_name: gfw-prodes-loss-api-develop
     environment:
-      PORT: 3600
+      PORT: 3602
       NODE_PATH: app/src
       NODE_ENV: dev
       CARTODB_USER: wri-01
       CT_URL: http://mymachine:9000
-      LOCAL_URL: http://mymachine:3600
+      CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
+      LOCAL_URL: http://mymachine:3602
       API_VERSION: v1
       CT_REGISTER_MODE: auto
       FASTLY_ENABLED: "false"


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Update port so it does not clash with other services
- Add missing token config